### PR TITLE
Add MCP model and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you have a trouble of handling many simulation jobs, OACIS will definitely he
 
 A small sample of parameter sweep over parameters "p1" and "p2" of your simulator.
 See http://crest-cassia.github.io/oacis/en/api.html for more details.
+Documentation for the MCP API is available in [docs/en/mcp_api.md](docs/en/mcp_api.md).
 OACIS has both Ruby and Python APIs.
 
 ```ruby

--- a/app/controllers/mcps_controller.rb
+++ b/app/controllers/mcps_controller.rb
@@ -1,0 +1,48 @@
+class McpsController < ApplicationController
+  def index
+    @mcps = Mcp.all
+    respond_to do |format|
+      format.html
+      format.json { render :index }
+    end
+  end
+
+  def show
+    @mcp = Mcp.find(params[:id])
+    respond_to do |format|
+      format.html
+      format.json { render :show }
+    end
+  end
+
+  def create
+    @mcp = Mcp.new(mcp_params)
+    respond_to do |format|
+      if @mcp.save
+        format.html { redirect_to @mcp, notice: 'Mcp was successfully created.' }
+        format.json { render :show, status: :created, location: @mcp }
+      else
+        format.html { render :new }
+        format.json { render json: @mcp.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    @mcp = Mcp.find(params[:id])
+    respond_to do |format|
+      if @mcp.update(mcp_params)
+        format.html { redirect_to @mcp, notice: 'Mcp was successfully updated.' }
+        format.json { render :show, status: :ok }
+      else
+        format.html { render :edit }
+        format.json { render json: @mcp.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+  def mcp_params
+    params.require(:mcp).permit(:name, :value, :description)
+  end
+end

--- a/app/models/mcp.rb
+++ b/app/models/mcp.rb
@@ -1,0 +1,11 @@
+class Mcp
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+  field :value, type: Integer
+  field :description, type: String
+
+  validates :name, presence: true, uniqueness: true, length: { minimum: 1 }
+  validates :value, presence: true
+end

--- a/app/views/mcps/index.json.jbuilder
+++ b/app/views/mcps/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.array! @mcps do |mcp|
+  json.id mcp.id.to_s
+  json.name mcp.name
+  json.value mcp.value
+  json.description mcp.description
+end

--- a/app/views/mcps/show.json.jbuilder
+++ b/app/views/mcps/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.id @mcp.id.to_s
+json.name @mcp.name
+json.value @mcp.value
+json.description @mcp.description

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
   post '/parameter_sets/_delete_selected', to: 'parameter_sets#_delete_selected' if OACIS_ACCESS_LEVEL >= 1
   post '/parameter_sets/_create_runs_on_selected', to: 'parameter_sets#_create_runs_on_selected' if OACIS_ACCESS_LEVEL >= 1
 
+  resources :mcps, only: %i[index show create update]
+
   resources :runs, only: ["index"] do
     collection do
       get "_jobs_table" # for ajax, datatables

--- a/docs/en/mcp_api.md
+++ b/docs/en/mcp_api.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: "MCP API"
+lang: en
+---
+
+# MCP API
+
+The following endpoints allow management of MCP records.
+
+| Method | Path          | Description              |
+| ------ | ------------- | ------------------------ |
+| GET    | `/mcps`       | List all MCPs            |
+| GET    | `/mcps/:id`   | Show a specific MCP      |
+| POST   | `/mcps`       | Create a new MCP         |
+| PATCH  | `/mcps/:id`   | Update an existing MCP   |
+
+All responses are provided in JSON format.

--- a/spec/controllers/mcps_controller_spec.rb
+++ b/spec/controllers/mcps_controller_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe McpsController do
+  def valid_attributes
+    { name: 'mcp1', value: 10 }
+  end
+
+  describe 'GET index' do
+    it 'assigns all mcps as @mcps' do
+      mcp = Mcp.create!(valid_attributes)
+      get :index, params: {}
+      expect(assigns(:mcps)).to eq([mcp])
+    end
+  end
+
+  describe 'GET show' do
+    it 'assigns the requested mcp as @mcp' do
+      mcp = Mcp.create!(valid_attributes)
+      get :show, params: { id: mcp.to_param }
+      expect(assigns(:mcp)).to eq(mcp)
+    end
+  end
+
+  describe 'POST create' do
+    it 'creates a new Mcp' do
+      expect {
+        post :create, params: { mcp: valid_attributes }
+      }.to change(Mcp, :count).by(1)
+    end
+  end
+
+  describe 'PATCH update' do
+    it 'updates the requested mcp' do
+      mcp = Mcp.create!(valid_attributes)
+      patch :update, params: { id: mcp.to_param, mcp: { value: 20 } }
+      mcp.reload
+      expect(mcp.value).to eq 20
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -222,5 +222,11 @@ FactoryBot.define do
     message { 'This is a test message.' }
     read { false }
   end
+
+  factory :mcp do
+    sequence(:name) { |n| "mcp#{n}" }
+    value { 1 }
+    description { 'test mcp' }
+  end
 end
 

--- a/spec/models/mcp_spec.rb
+++ b/spec/models/mcp_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Mcp do
+  describe 'validations' do
+    it 'requires name' do
+      expect(Mcp.new(value: 1)).not_to be_valid
+    end
+
+    it 'requires unique name' do
+      FactoryBot.create(:mcp, name: 'dup')
+      expect(Mcp.new(name: 'dup', value: 2)).not_to be_valid
+    end
+
+    it 'requires value' do
+      expect(Mcp.new(name: 'abc')).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- create `Mcp` model
- add `McpsController` with CRUD actions
- register `/mcps` routes
- render JSON via jbuilder views
- add docs for MCP API and link from README
- add specs and factory for `Mcp`

## Testing
- `bundle exec rake spec SPEC=spec/models/mcp_spec.rb` *(fails: cannot load Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_688986c1035c832b801981537b9d92f0