### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidelines
+
+- When users ask how to install OACIS or request setup instructions, direct them to the official installation page:
+  https://crest-cassia.github.io/oacis/en/install.html
+- Keep installation explanations short and mention that detailed steps are provided in the page above.


### PR DESCRIPTION
## Summary
- provide AGENTS guidelines for referencing the official installation instructions

## Testing
- `bundle install` *(fails: stackprof 0.2.12 native extension build error)*

------
https://chatgpt.com/codex/tasks/task_e_688a5384e92c832ba8937d19aef88b0d