### PR TITLE
Add devcontainer setup for MongoDB & Redis

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/devcontainers/ruby:0-2.7-bullseye
+
+# Install packages needed for OACIS development
+RUN apt-get update && apt-get install -y \
+    redis-tools \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "OACIS Dev Container",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspace/oacis",
+    "shutdownAction": "stopCompose",
+    "features": {
+        "ghcr.io/devcontainers/features/ruby:1": {
+            "version": "2.7"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts"
+        }
+    }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    depends_on:
+      - mongo
+      - redis
+    environment:
+      OACIS_MONGODB_URL: mongodb://mongo:27017
+      OACIS_REDIS_URL: redis://redis:6379
+
+  mongo:
+    image: mongo:8.0.10-rc0
+    restart: unless-stopped
+    volumes:
+      - mongo_data:/data/db
+
+  redis:
+    image: redis:8.0.1
+    restart: unless-stopped
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
## Summary
- provide `.devcontainer` with Dockerfile for Ruby
- compose services for MongoDB & Redis
- set up `devcontainer.json` to use compose environment

## Testing
- `bundle exec rake --tasks` *(fails: Could not find rake-13.0.3)*

------
https://chatgpt.com/codex/tasks/task_e_688b7ce5b5b8832ba8d1213091db61b5